### PR TITLE
refactor SCHEDULER object

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -23,7 +23,6 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
-
     SCHEDULER = setup_scheduler()
 
     yield

--- a/src/api.py
+++ b/src/api.py
@@ -23,10 +23,10 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
-    SCHEDULER = setup_scheduler()
+    scheduler = setup_scheduler()
 
     yield
-    SCHEDULER.shutdown(wait=False)
+    scheduler.shutdown(wait=False)
 
 
 def get_session():

--- a/src/api.py
+++ b/src/api.py
@@ -21,12 +21,9 @@ from src.models import BackupSchedule, BackupVolume, BackupVolumeResponse, Volum
 logger = logging.getLogger(__name__)
 
 
-SCHEDULER = None
-
-
 @asynccontextmanager
 async def lifespan(_: FastAPI):
-    global SCHEDULER
+
     SCHEDULER = setup_scheduler()
 
     yield
@@ -95,9 +92,7 @@ def api_backup_volume(volume_name: str) -> BackupVolumeResponse:
             detail=f"Volume {volume_name} is attached to a container",
         )
 
-    task = add_backup_job(
-        SCHEDULER, f"backup-{volume_name}-{str(uuid.uuid4())}", volume_name
-    )
+    task = add_backup_job(f"backup-{volume_name}-{str(uuid.uuid4())}", volume_name)
     logger.info(
         "backup %s started task id: %s",
         volume_name,
@@ -121,7 +116,6 @@ def api_restore_volume(
         backup_volume.backup_filename,
     )
     task = add_restore_job(
-        SCHEDULER,
         f"restore-{backup_volume.volume_name}-{str(uuid.uuid4())}",
         backup_volume.volume_name,
         backup_volume.backup_filename,
@@ -143,7 +137,7 @@ def api_restore_volume(
 )
 def api_get_backup_schedule(schedule_name: str) -> BackupSchedule:
     logger.info("Getting schedule %s", schedule_name)
-    schedule = get_backup_schedule(SCHEDULER, schedule_name)
+    schedule = get_backup_schedule(schedule_name)
     if not schedule:
         raise HTTPException(
             status_code=404,
@@ -155,7 +149,7 @@ def api_get_backup_schedule(schedule_name: str) -> BackupSchedule:
 @app.get("/volumes/backup/schedule", description="Get a list of backup schedules")
 def api_list_backup_schedules() -> list[BackupSchedule]:
     # TODO: add filters e.g volume_name, cron schedule
-    return list_backup_schedules(SCHEDULER)
+    return list_backup_schedules()
 
 
 @app.delete(
@@ -164,7 +158,7 @@ def api_list_backup_schedules() -> list[BackupSchedule]:
 def api_remove_backup_schedule(schedule_name: str) -> str:
     logger.info("Removing schedule %s", schedule_name)
     try:
-        delete_backup_schedule(SCHEDULER, schedule_name)
+        delete_backup_schedule(schedule_name)
     except JobLookupError as e:
         raise HTTPException(
             status_code=404,
@@ -187,7 +181,6 @@ async def api_create_backup_schedule(
 
     try:
         job = add_backup_job(
-            SCHEDULER,
             schedule_body.schedule_name,
             schedule_body.volume_name,
             schedule_body.crontab,

--- a/src/apschedule.py
+++ b/src/apschedule.py
@@ -85,9 +85,7 @@ def add_restore_job(
     )
 
 
-def get_backup_schedule(
-    scheduler: AsyncIOScheduler, schedule_name: str
-) -> BackupSchedule | None:
+def get_backup_schedule(schedule_name: str) -> BackupSchedule | None:
     job = SCHEDULER.get_job(schedule_name)
     if job:
         return map_job_to_backup_schedule(job)
@@ -95,11 +93,11 @@ def get_backup_schedule(
     return job
 
 
-def list_backup_schedules(scheduler: AsyncIOScheduler) -> list[BackupSchedule]:
+def list_backup_schedules() -> list[BackupSchedule]:
     return [map_job_to_backup_schedule(job) for job in SCHEDULER.get_jobs()]
 
 
-def delete_backup_schedule(scheduler: AsyncIOScheduler, schedule_name: str):
+def delete_backup_schedule(schedule_name: str):
     return SCHEDULER.remove_job(schedule_name)
 
 

--- a/src/apschedule.py
+++ b/src/apschedule.py
@@ -19,6 +19,7 @@ TZ = os.environ.get("TZ", "UTC")
 
 SCHEDULER = None
 
+
 def setup_scheduler() -> AsyncIOScheduler:
     global SCHEDULER
     jobstores = {"default": SQLAlchemyJobStore(url=APSCHEDULE_JOBSTORE_URL)}

--- a/src/apschedule.py
+++ b/src/apschedule.py
@@ -17,22 +17,23 @@ APSCHEDULE_JOBSTORE_URL = os.environ.get(
 )
 TZ = os.environ.get("TZ", "UTC")
 
+SCHEDULER = None
 
 def setup_scheduler() -> AsyncIOScheduler:
+    global SCHEDULER
     jobstores = {"default": SQLAlchemyJobStore(url=APSCHEDULE_JOBSTORE_URL)}
-    scheduler = AsyncIOScheduler(jobstores=jobstores, timezone=TZ)
-    scheduler.start()
-    return scheduler
+    SCHEDULER = AsyncIOScheduler(jobstores=jobstores, timezone=TZ)
+    SCHEDULER.start()
+    return SCHEDULER
 
 
 def add_backup_job(
-    schedule: AsyncIOScheduler,
     job_name: str,
     volume_name: str,
     crontab: ScheduleCrontab = None,
 ):
     if crontab:
-        return schedule.add_job(
+        return SCHEDULER.add_job(
             func=backup_volume,
             trigger=CronTrigger(
                 minute=crontab.minute,
@@ -47,7 +48,7 @@ def add_backup_job(
             replace_existing=False,
         )
 
-    return schedule.add_job(
+    return SCHEDULER.add_job(
         func=backup_volume,
         id=job_name,
         name=job_name,
@@ -58,14 +59,13 @@ def add_backup_job(
 
 
 def add_restore_job(
-    schedule: AsyncIOScheduler,
     job_name: str,
     volume_name: str,
     backup_filename: str,
     crontab: ScheduleCrontab = None,
 ):
     if crontab:
-        return schedule.add_job(
+        return SCHEDULER.add_job(
             func=restore_volume,
             trigger=CronTrigger(**crontab),
             id=job_name,
@@ -74,7 +74,7 @@ def add_restore_job(
             replace_existing=False,
         )
 
-    return schedule.add_job(
+    return SCHEDULER.add_job(
         func=restore_volume,
         id=job_name,
         name=job_name,
@@ -87,7 +87,7 @@ def add_restore_job(
 def get_backup_schedule(
     scheduler: AsyncIOScheduler, schedule_name: str
 ) -> BackupSchedule | None:
-    job = scheduler.get_job(schedule_name)
+    job = SCHEDULER.get_job(schedule_name)
     if job:
         return map_job_to_backup_schedule(job)
 
@@ -95,11 +95,11 @@ def get_backup_schedule(
 
 
 def list_backup_schedules(scheduler: AsyncIOScheduler) -> list[BackupSchedule]:
-    return [map_job_to_backup_schedule(job) for job in scheduler.get_jobs()]
+    return [map_job_to_backup_schedule(job) for job in SCHEDULER.get_jobs()]
 
 
 def delete_backup_schedule(scheduler: AsyncIOScheduler, schedule_name: str):
-    return scheduler.remove_job(schedule_name)
+    return SCHEDULER.remove_job(schedule_name)
 
 
 def map_job_to_backup_schedule(job: Job):

--- a/src/worker.py
+++ b/src/worker.py
@@ -1,7 +1,0 @@
-from datetime import datetime, timezone
-from src.docker import backup_volume
-def backup_volume_task(volume_name):
-    dt_now = datetime.now(tz=timezone.utc)
-    backup_file = f"{volume_name}-{dt_now.isoformat()}.tar.gz"
-    backup_volume(volume_name)
-

--- a/src/worker.py
+++ b/src/worker.py
@@ -1,0 +1,7 @@
+from datetime import datetime, timezone
+from src.docker import backup_volume
+def backup_volume_task(volume_name):
+    dt_now = datetime.now(tz=timezone.utc)
+    backup_file = f"{volume_name}-{dt_now.isoformat()}.tar.gz"
+    backup_volume(volume_name)
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,7 +151,6 @@ def test_create_backup(mocker, client):
     mock_get_volume.assert_called_once_with("test-volume")
     mock_is_volume_attached.assert_called_once_with("test-volume")
     mock_create_volume_backup.assert_called_once_with(
-        None,
         "backup-test-volume-test-uuid",
         "test-volume",
     )
@@ -199,7 +198,7 @@ def test_restore_backup(mocker, client):
         "task_id": "test-task-id",
     }
     mock_create_volume_backup.assert_called_once_with(
-        None, "restore-test-volume-test-uuid", "test-volume", "test-backup-name.tar.gz"
+        "restore-test-volume-test-uuid", "test-volume", "test-backup-name.tar.gz"
     )
 
 
@@ -240,7 +239,6 @@ def test_create_schedule(mocker, client):
     }
     mock_get_volume.assert_called_once_with("test-volume")
     mock_create_volume_backup.assert_called_once_with(
-        None,
         "test-schedule",
         "test-volume",
         ScheduleCrontab(minute="1", hour="2", day="*", month="*", day_of_week="*"),
@@ -271,7 +269,7 @@ def test_get_schedule(mocker, client):
             "day_of_week": "*",
         },
     }
-    mock_get_schedule.assert_called_once_with(None, "test-schedule")
+    mock_get_schedule.assert_called_once_with("test-schedule")
 
 
 def test_get_schedule_not_found(mocker, client):
@@ -282,7 +280,7 @@ def test_get_schedule_not_found(mocker, client):
     response = client.get("/volumes/backup/schedule/test-schedule")
     assert response.status_code == 404
     assert response.json() == {"detail": "Schedule job test-schedule does not exist"}
-    mock_get_schedule.assert_called_once_with(None, "test-schedule")
+    mock_get_schedule.assert_called_once_with("test-schedule")
 
 
 def test_list_schedule(mocker, client):
@@ -313,7 +311,7 @@ def test_list_schedule(mocker, client):
             },
         }
     ]
-    mock_list_schedule.assert_called_once_with(None)
+    mock_list_schedule.assert_called_once_with()
 
 
 def test_remove_schedule(mocker, client):
@@ -323,7 +321,7 @@ def test_remove_schedule(mocker, client):
     response = client.delete("/volumes/backup/schedule/test-schedule")
     assert response.status_code == 200
     assert response.json() == "Schedule test-schedule removed"
-    mock_remove_schedule.assert_called_once_with(None, "test-schedule")
+    mock_remove_schedule.assert_called_once_with("test-schedule")
 
 
 def test_remove_schedule_not_found(mocker, client):
@@ -334,4 +332,4 @@ def test_remove_schedule_not_found(mocker, client):
     response = client.delete("/volumes/backup/schedule/test-schedule")
     assert response.status_code == 404
     assert response.json() == {"detail": "Schedule job test-schedule does not exist"}
-    mock_remove_schedule.assert_called_once_with(None, "test-schedule")
+    mock_remove_schedule.assert_called_once_with("test-schedule")


### PR DESCRIPTION
api handlers don't need access to the scheduler object as it should be called by a function inside apschedule file