### PR TITLE
ensure that window height is consistent per tab

### DIFF
--- a/src/static/site.css
+++ b/src/static/site.css
@@ -3,9 +3,12 @@
     top: 0px;
     position: absolute;
     width: 100%;
-    max-width: 100%;
-    max-height: 100%;
-    min-height: 390px;
+    min-height: 700px;
+}
+
+#docker-homelab-manager-window  article {
+    position: relative;
+    min-height: 700px;
 }
 
 


### PR DESCRIPTION
to make it similar to how windows 95 ui windows are
![Screenshot from 2024-05-05 07-02-22](https://github.com/mrllama123/docker-homelab-manager/assets/9062832/c14615db-4edb-4647-89e4-bd46b3c68d7c)
